### PR TITLE
rake preview でウェブサーバを起動するように

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,8 @@ task :deploy do
   sh "git checkout master"
 end
 
+desc "preview website"
+task :preview do
+  require "webrick"
+  WEBrick::HTTPServer.new(:DocumentRoot => ".", :Port => 4000).start
+end


### PR DESCRIPTION
```
# Usage: rake preveiw
```

とかかれているのに `rake preview` コマンドが存在しないので追加してみました。
