### PR TITLE
Fix remarkがごみの日に混入する

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -210,7 +210,7 @@ var TrashModel = function(_lable, _cell, remarks) {
             }
             //特定の週のみ処理する
             if (day_mix[j].length > 1) {
-              if (week != day_mix[j].charAt(1) - 1) {
+              if ((week != day_mix[j].charAt(1) - 1) || ("*" == day_mix[j].charAt(0))) {
                 continue;
               }
             }


### PR DESCRIPTION
day_mix[j] が "*1" といったremarkの場合、continueへ進まずそのまま day_list へ push されて誤ったごみの日を表示してしまう.
day_mix[j].charAt(0) が "*" の場合も day_list へ含まないように条件追加.
