### PR TITLE
未来のデータがない場合にカテゴリーのソートに失敗する件を修正

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -49,8 +49,17 @@ var AreaModel = function() {
     this.trash.sort(function(a, b) {
       if (a.mostRecent === undefined) return 1;
       if (b.mostRecent === undefined) return -1;
-      var at = a.mostRecent.getTime();
-      var bt = b.mostRecent.getTime();
+      var amr = a.mostRecent;
+      var bmr = b.mostRecent;
+      if (!amr && !bmr) {
+        return 0;
+      } else if (amr && !bmr) {
+        return -1;
+      } else if (!amr && bmr) {
+        return 1;
+      }
+      var at = amr.getTime();
+      var bt = bmr.getTime();
       if (at < bt) return -1;
       if (at > bt) return 1;
       return 0;


### PR DESCRIPTION
5374.jp 札幌版で未来のデータがない場合にスクリプトエラーとなる件の修正を行いました。
master版のKanazawaソースではほぼ対応済みでしたが、カテゴリーのソートについては未対応だったためPRします。
ご検討ください。
