### PR TITLE
CSVのデータを日付に変換する際に無効な日付データがあったら取り除くように修正

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -264,7 +264,9 @@ var TrashModel = function(_lable, _cell, remarks) {
         var month = parseInt(day_mix[j].substr(4, 2)) - 1;
         var day = parseInt(day_mix[j].substr(6, 2));
         var d = new Date(year, month, day);
-        day_list.push(d);
+        if (d.toString() !== "Invalid Date") {
+            day_list.push(d);
+        }
       }
     }
     //曜日によっては日付順ではないので最終的にソートする。


### PR DESCRIPTION
area_days.csvに、`*7` のような注釈用の文字を含む場合、Invalid DateなDateになってしまいます。
Invalid DateなDateはgetTime()を取得するとNaNが返ります。

NaN値は比較時どんな値でもfalseがになるためソート後の配列が正しくソートされない場合があります。
そのためInvalid Dateは変換後の配列に含めないように修正しました。
